### PR TITLE
feat(linear): Slackリンク取得機能を実装

### DIFF
--- a/apps/agent/src/mastra/linear/agents/next-action-agent.ts
+++ b/apps/agent/src/mastra/linear/agents/next-action-agent.ts
@@ -18,6 +18,7 @@ description: z.string().min(1), // 何をするか
 ownerRole: ZOwnerRole, // engineer / customerSuccess
 priority: ZPriority, // high / middle / low
 ticketId: z.string().min(1), // 対象チケットID
+slackUrl: z.string().url().nullable(), // 関連するSlackのメッセージ or スレッドURL
 confidence: z.number().int().min(1).max(5), // 解決策への自信度 1..5 (1=低い, 5=高い)
 rationale: z.string().min(1), // 判断理由
 investigation: ZInvestigation.optional(), // 必要時のみ

--- a/apps/agent/src/mastra/linear/tools/linear-tool.ts
+++ b/apps/agent/src/mastra/linear/tools/linear-tool.ts
@@ -54,7 +54,9 @@ async function getTriageIssues(teamKey: string) {
       description: issue.description || null,
       status: "Triage",
       priority: issue.priority || null,
-      // assignee: issue.assignee ? (await issue.assignee).displayName || null : null,
+      slackLink: issue.attachments ? (await issue.attachments()).nodes
+    .filter((att) => att.url.includes("slack.com")) // only Slack links
+    .map((att) => att.url)[0] || null : null,
     })),
   );
 

--- a/apps/agent/src/mastra/prompts/create-next-action.ts
+++ b/apps/agent/src/mastra/prompts/create-next-action.ts
@@ -42,6 +42,7 @@ export const ZActionProposal = z.object({
   ownerRole: ZOwnerRole, // engineer / customerSuccess
   priority: ZPriority, // high / middle / low
   ticketId: z.string(), // 対象チケットID
+  slackUrl: z.string().nullish(), // 関連するSlackのメッセージ or スレッドURL
   confidence: z.number(), // 解決策への自信度 1..5 (この解決策が問題を適切に解決できる確信レベル)
   rationale: z.string(), // 判断理由
   investigation: ZInvestigation.nullish(), // 必要時のみ

--- a/apps/agent/src/mastra/schema/linear-issue.ts
+++ b/apps/agent/src/mastra/schema/linear-issue.ts
@@ -6,5 +6,6 @@ export const linearIssueSchema = z.object({
   description: z.string().nullable(),
   status: z.string(),
   priority: z.number().nullable(),
+  slackLink: z.string().nullable(),
 });
 export type LinearIssueSchemaType = z.infer<typeof linearIssueSchema>;

--- a/apps/agent/src/mastra/schema/linear-tool.ts
+++ b/apps/agent/src/mastra/schema/linear-tool.ts
@@ -11,6 +11,7 @@ export const linearToolOutputSchema = z.array(
     description: z.string().nullable(),
     status: z.string(),
     priority: z.number().nullable(),
+    slackLink: z.string().nullable(),
     // assignee: z.string().nullable(),
   }),
 );


### PR DESCRIPTION
- linear-toolでSlackリンクを抽出する機能を追加
- 複数のSlackリンクではなく最初の1つのみを取得
- スキーマにslackLinkフィールドを追加
- next-action-agentでSlackリンク情報を活用できるよう拡張