### PR TITLE
バグ報告と機能要望をクラスタリングする

### DIFF
--- a/apps/agent/src/mastra/linear/agents/cluster-agent.ts
+++ b/apps/agent/src/mastra/linear/agents/cluster-agent.ts
@@ -6,87 +6,30 @@ import { Memory } from "@mastra/memory";
 export const clusterAgent = new Agent({
   name: "cluster-agent",
   instructions: `あなたは バグ修正と機能要望に関する質問や解決策をクラスタリングするエージェントです。
-  受け取った情報を分類・整理し、どの課題にどの程度のインパクトがあるかを推定する手助けをします。
+  受け取った情報を分類・整理し、どの課題にどの程度のインパクトがあるかを推定する手助けをします。ただし以下のルールに注意すること。
+- 提示された 解決策をクラスタリング し、関連性のあるものをまとめる
+- なぜそのクラスタリングを行ったのか理由を明確にする
+- そのクラスタリングにおける確信度を5段階消化で出力する。(5が最も確信していて、1が自信ない)
+- 各クラスタが バグ修正に関するものか／機能要望に関するものか を明確にする
+次のようなスキーマを期待しています
+const SolutionItem = z.object({
+  id: z.string(),      // 元のデータID
+  description: z.string(), // 内容（解決策の本文など）
+});
 
-入力として受け取るのは、nextActionsの配列です。各actionには以下が含まれます：
-- title, description, ownerRole, priority, ticketId, confidence, rationale
-- 場合によってはquestions配列やinvestigation情報
-
-以下のルールに従ってクラスタリングしてください：
-- 関連性のあるアクションをクラスタリングし、質問と解決策に分離する
-- なぜそのクラスタリングを行ったのか理由を明確にする  
-- そのクラスタリングにおける確信度を5段階で出力する（5が最も確信、1が自信なし）
-- 各クラスタがバグ修正に関するものか機能要望に関するものかを明確にする
-- 質問と解決策は分けてクラスタリングを行う
-
-出力スキーマ：
-{
-  context: {
-    generatedAt?: string (ISO datetime),
-    inputSummary?: string,
-    totalItems?: number
-  },
-  questionClusters: [
-    {
-      id: string,
-      title: string,
-      clusterType: "bugfix" | "feature",
-      clusterOf: "question",
-      representativeExample?: string,
-      whyGrouped: string,
-      confidence: number (1-5),
-      impact: {
-        score: number (1-5),
-        rationale: string,
-        areas?: ["usability", "reliability", "performance", "security", "compliance", "scalability", "cost", "devex"]
-      },
-      items: [
-        {
-          id: string,
-          text: string,
-          kind: "question",
-          source?: string,
-          meta?: any
-        }
-      ],
-      relatedClusterIds?: string[],
-      notes?: string
-    }
-  ],
-  solutionClusters: [
-    {
-      id: string,
-      title: string,
-      clusterType: "bugfix" | "feature", 
-      clusterOf: "solution",
-      representativeExample?: string,
-      whyGrouped: string,
-      confidence: number (1-5),
-      impact: {
-        score: number (1-5),
-        rationale: string,
-        areas?: ["usability", "reliability", "performance", "security", "compliance", "scalability", "cost", "devex"]
-      },
-      items: [
-        {
-          id: string,
-          text: string,
-          kind: "solution",
-          source?: string,
-          meta?: any
-        }
-      ],
-      relatedClusterIds?: string[],
-      notes?: string
-    }
-  ],
-  unclustered?: []
-}
-
-注意：
-- questionClustersには clusterOf="question" のみ
-- solutionClustersには clusterOf="solution" のみ
-- itemsのkindは対応するclusterOfと一致させる
+// まとめられたクラスタ
+const SolutionCluster = z.object({
+  clusterId: z.string(),      // クラスタのID
+  clusterTitle: z.string(),   // クラスタの名前（簡単な見出し）
+  category: z.number(),         // バグ修正 or 機能要望
+  rationale: z.string(),      // なぜこのクラスタにまとめたか
+  confidence: z.number(),     // 確信度1〜5（1:自信なし, 5:とても自信あり）
+  impact: ImpactLevel,        // インパクトの推定大きさ 1〜5（1:小さい, 5:大きい）
+  solutions: z.array(SolutionItem), // このクラスタに含まれる解決策
+});
+export const ClusteringOutputSchema = z.object({
+  clusters: z.array(SolutionCluster), // 解決策クラスタの一覧
+});
 `,
   model: anthropic("claude-3-7-sonnet-20250219"),
   memory: new Memory({

--- a/apps/agent/src/mastra/linear/tools/linear-tool.ts
+++ b/apps/agent/src/mastra/linear/tools/linear-tool.ts
@@ -41,7 +41,7 @@ async function getTriageIssues(teamKey: string) {
       state: { id: { eq: triageState.id } },
       team: { id: { eq: team.id } },
     },
-    first: 3, // pagination size
+    first: 20, // pagination size
   });
 
   const allIssues = issues.nodes;

--- a/apps/agent/src/mastra/linear/workflows/linear-workflow.ts
+++ b/apps/agent/src/mastra/linear/workflows/linear-workflow.ts
@@ -1,8 +1,10 @@
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import prettier from "prettier";
-import { ZActionProposal } from "../../prompts/create-next-action";
 import { ClusteringOutputSchema } from "../../prompts/create-cluster";
+import { ZActionProposal } from "../../prompts/create-next-action";
 import {
+  clusterHighConfidenceActionsStepInputSchema,
+  clusterHighConfidenceActionsStepOutputSchema,
   exportTempFileStepInputSchema,
   exportTempFileStepOutputSchema,
   exportTempFileStepResumeSchema,
@@ -10,18 +12,13 @@ import {
   fetchTriageStepOutputSchema,
   linearTriageWorkflowInputSchema,
   linearTriageWorkflowOutputSchema,
-  sendSlackQuestionStepInputSchema,
-  sendSlackQuestionStepOutputSchema,
   suggestNextActionsStepInputSchema,
   suggestNextActionsStepOutputSchema,
   waitForHumanApproveStepInputSchema,
   waitForHumanApproveStepOutputSchema,
   waitForHumanApproveStepResumeSchema,
-  clusterHighConfidenceActionsStepInputSchema,
-  clusterHighConfidenceActionsStepOutputSchema,
 } from "../../schema/workflow-steps";
 import { linearTool } from "../tools/linear-tool";
-import { slackTool } from "../tools/slack-tool";
 import { writeFilesTool } from "../tools/write-files";
 
 const fetchTriageStep = createStep({
@@ -123,69 +120,6 @@ const waitForHumanApproveOrFixStep = createStep({
   },
 });
 
-const sendSlackQuestionStep = createStep({
-  id: "send-slack-question",
-  description: "必要に応じてSlackで質問を送信する",
-  inputSchema: sendSlackQuestionStepInputSchema,
-  outputSchema: sendSlackQuestionStepOutputSchema,
-  execute: async ({ inputData, runtimeContext, tracingContext }) => {
-    const { nextActions } = inputData;
-    const actionsWithQuestions = nextActions.filter(
-      (action) => action.questions && action.questions.length > 0,
-    );
-    if (actionsWithQuestions.length === 0) {
-      return {
-        oks: [],
-        slackUrls: [],
-        nextActions,
-      };
-    }
-
-    const questionsWithActions = actionsWithQuestions.flatMap(
-      (action) =>
-        action.questions?.map((question) => ({
-          question,
-          slackUrl: action.slackUrl,
-        })) || [],
-    );
-
-    const responses = await Promise.all(
-      questionsWithActions
-        .filter(
-          ({ question }) => question?.necessity && question?.necessity > 3,
-        )
-        .map(({ question, slackUrl }) => {
-          const message = `質問があります: ${question?.content}
-宛先: ${question?.toRole}${question?.toName ? ` (${question?.toName})` : ""}
-必要度: ${question?.necessity}/5
-`;
-          // TEST HARDCODE TO AVOID SPAM
-          slackUrl =
-            "https://medimo-pleap.slack.com/archives/C06DEFWUSNM/p1757140310736399";
-
-          if (slackUrl) {
-            return slackTool.execute({
-              context: { slackUrl, message },
-              runtimeContext,
-              tracingContext,
-            });
-          }
-          return {
-            ok: false,
-            slackUrl: "",
-            ts: "",
-          };
-        }),
-    );
-
-    return {
-      oks: responses.map((res) => res.ok),
-      slackUrls: responses.map((res) => res.slackUrl),
-      nextActions,
-    };
-  },
-});
-
 const clusterHighConfidenceActionsStep = createStep({
   id: "cluster-high-confidence-actions",
   description: "自信度の高いアクションをクラスタリングする",
@@ -193,56 +127,26 @@ const clusterHighConfidenceActionsStep = createStep({
   outputSchema: clusterHighConfidenceActionsStepOutputSchema,
   execute: async ({ inputData, mastra }) => {
     const { nextActions } = inputData;
-    const highConfidenceActions = nextActions.filter(
-      (action) => action.confidence >= 4,
-    );
-
-    if (highConfidenceActions.length === 0) {
-      // Return empty clustering result if no high-confidence actions
-      return {
-        // nextActions,
-        clustering: {
-          context: {
-            generatedAt: new Date().toISOString(),
-            inputSummary: "No high-confidence actions to cluster",
-            totalItems: 0,
-          },
-          questionClusters: [],
-          solutionClusters: [],
-          unclustered: [],
-        },
-      };
-    }
-
-    try {
-      // Cluster by calling the LLM and grouping similar actions together
-      const agent = mastra.getAgent("clusterAgent");
-      const clustering = await agent.generate(JSON.stringify(highConfidenceActions), {
-        output: ClusteringOutputSchema,
+    const highConfidenceActions = nextActions
+      .filter((action) => action.confidence >= 4)
+      .map((action) => {
+        delete action.questions;
+        return action;
       });
 
-      return {
-        // nextActions,
-        clustering: clustering.object,
-      };
-    } catch (error) {
-      console.error("Clustering failed:", error);
-      // Return empty clustering result on error
-      return {
-        // nextActions,
-        clustering: {
-          context: {
-            generatedAt: new Date().toISOString(),
-            inputSummary: `Clustering failed: ${(error as Error).message}`,
-            totalItems: highConfidenceActions.length,
-          },
-          questionClusters: [],
-          solutionClusters: [],
-          unclustered: [],
-        },
-      };
-    }
-  }
+    // Cluster by calling the LLM and grouping similar actions together
+    const agent = mastra.getAgent("clusterAgent");
+    const clustering = await agent.generate(
+      JSON.stringify(highConfidenceActions),
+      {
+        output: ClusteringOutputSchema,
+      },
+    );
+
+    return {
+      clustering: clustering.object,
+    };
+  },
 });
 
 export const linearTriageWorkflow = createWorkflow({
@@ -256,6 +160,5 @@ export const linearTriageWorkflow = createWorkflow({
   .then(suggesNextActionsStep)
   .then(exportTempFileForHumanReviewStep)
   .then(waitForHumanApproveOrFixStep)
-  .then(sendSlackQuestionStep)
   .then(clusterHighConfidenceActionsStep)
   .commit();

--- a/apps/agent/src/mastra/prompts/create-cluster.ts
+++ b/apps/agent/src/mastra/prompts/create-cluster.ts
@@ -1,128 +1,33 @@
 import { z } from "zod";
 
-/** 入力アイテム（前処理や未クラスタ項目保持に使う想定） */
-export const ItemSchema = z
-  .object({
-    id: z.string(),
-    /** 原文 */
-    text: z.string(),
-    /** アイテムの種類：質問 or 解決策 */
-    kind: z.enum(["question", "solution"]),
-    /** 追加メタ：起票者/チケット/タグ等（任意） */
-    meta: z.record(z.any()).optional(),
-  })
-  .strict();
+// バグ修正 or 機能要望
+const Category = z.enum(["bugfix", "feature"]);
 
-export type Item = z.infer<typeof ItemSchema>;
+// 確信度 1〜5（1:自信なし, 5:とても自信あり）
+const Confidence = z.number();
 
-/** 影響領域（任意だがあると優先度議論が楽） */
-export const ImpactAreaSchema = z
-  .array(
-    z.enum([
-      "usability",
-      "reliability",
-      "performance",
-      "security",
-      "compliance",
-      "scalability",
-      "cost",
-      "devex",
-    ]),
-  )
-  .default([]);
+// インパクトの大きさ 1〜5（1:小さい, 5:大きい）
+const ImpactLevel = z.number();
 
-/** インパクト推定（必須） */
-export const ImpactEstimateSchema = z
-  .object({
-    /** 1–5（5が最大インパクト） */
-    score: z.number(),
-    /** なぜその評価か（必須） */
-    rationale: z.string(),
-    /** 影響領域のタグ（任意・複数可） */
-    areas: ImpactAreaSchema.optional(),
-  })
-  .strict();
+// 個別のアイテム（元の課題や解決策のテキスト）
+const SolutionItem = z.object({
+  id: z.string(), // 元のデータID
+  description: z.string(), // 内容（解決策の本文など）
+});
 
-/** クラスタ（質問用/解決策用で共通） */
-export const ClusterSchema = z
-  .object({
-    /** クラスタID */
-    id: z.string(),
-    /** 見出し */
-    title: z.string(),
-    /** バグ修正 or 機能要望 */
-    clusterType: z.enum(["bugfix", "feature"]),
-    /** このクラスタが “質問” をまとめたものか “解決策” をまとめたものか */
-    clusterOf: z.enum(["question", "solution"]),
-    /** 代表例（任意） */
-    representativeExample: z.string().optional(),
-    /** なぜまとめたか（必須） */
-    whyGrouped: z.string(),
-    /** 確信度 1–5（必須） */
-    confidence: z.number(),
-    /** インパクト推定（必須） */
-    impact: ImpactEstimateSchema,
-    /** メンバー項目（必須） */
-    items: z.array(
-      z
-        .object({
-          id: z.string(),
-          text: z.string(),
-          kind: z.enum(["question", "solution"]),
-          /** 出典リンクやチケットIDなど（任意） */
-          source: z.string().optional(),
-          meta: z.record(z.any()).optional(),
-        })
-        .strict(),
-    ),
-    /** 関連クラスタ（片方向でOK。質問⇄解決策の対応付けに） */
-    relatedClusterIds: z.array(z.string()).default([]),
-    /** 補足（任意） */
-    notes: z.string().optional(),
-  })
-  .strict()
-  .superRefine((cluster, ctx) => {
-    // 1) クラスタ内の kind が cluster.clusterOf と一致していることを強制
-    const bad = cluster.items.find((it) => it.kind !== cluster.clusterOf);
-    if (bad) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["items"],
-        message: `items[].kind はクラスタの clusterOf="${cluster.clusterOf}" と一致している必要があります（混在禁止）。`,
-      });
-    }
-  });
+// まとめられたクラスタ
+const SolutionCluster = z.object({
+  clusterId: z.string(), // クラスタのID
+  clusterTitle: z.string(), // クラスタの名前（簡単な見出し）
+  category: Category, // バグ修正 or 機能要望
+  rationale: z.string(), // なぜこのクラスタにまとめたか
+  confidence: Confidence, // 確信度
+  impact: ImpactLevel, // インパクト推定
+  solutions: z.array(SolutionItem), // このクラスタに含まれる解決策
+});
 
-export type Cluster = z.infer<typeof ClusterSchema>;
-
-/** 出力のトップレベル：質問クラスタと解決策クラスタを明確に分離 */
-export const ClusteringOutputSchema = z
-  .object({
-    /** 任意のコンテキスト（解析対象の概要や時刻など） */
-    context: z
-      .object({
-        generatedAt: z.string().datetime().optional(),
-        inputSummary: z.string().optional(),
-        totalItems: z.number().int().nonnegative().optional(),
-      })
-      .default({}),
-    /** 質問クラスタ（clusterOf=question のみ許可） */
-    questionClusters: z
-      .array(ClusterSchema)
-      .refine((arr) => arr.every((c) => c.clusterOf === "question"), {
-        message:
-          'questionClusters には clusterOf="question" のみを入れてください。',
-      }),
-    /** 解決策クラスタ（clusterOf=solution のみ許可） */
-    solutionClusters: z
-      .array(ClusterSchema)
-      .refine((arr) => arr.every((c) => c.clusterOf === "solution"), {
-        message:
-          'solutionClusters には clusterOf="solution" のみを入れてください。',
-      }),
-    /** 未クラスタ項目（任意・あとで手動振り分け用） */
-    unclustered: z.array(ItemSchema).default([]),
-  })
-  .strict();
-
+// エージェントの出力全体
+export const ClusteringOutputSchema = z.object({
+  clusters: z.array(SolutionCluster), // 解決策クラスタの一覧
+});
 export type ClusteringOutput = z.infer<typeof ClusteringOutputSchema>;

--- a/apps/agent/src/mastra/schema/workflow-steps.ts
+++ b/apps/agent/src/mastra/schema/workflow-steps.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
+import { ClusteringOutputSchema } from "../prompts/create-cluster";
 import { ZActionProposal } from "../prompts/create-next-action";
 import {
   writeFileOutputSchema,
   writtenFileShcema,
 } from "../prompts/write-files";
 import { linearIssueSchema } from "./linear-issue";
-import { ClusteringOutputSchema } from "../prompts/create-cluster";
 
 // Workflow step input schemas
 export const fetchTriageStepInputSchema = z.object({
@@ -64,9 +64,8 @@ export const sendSlackQuestionStepOutputSchema = z.object({
 });
 
 export const clusterHighConfidenceActionsStepInputSchema = z.object({
-  oks: z.array(z.boolean()),
-  slackUrls: z.array(z.string().url()),
   nextActions: z.array(ZActionProposal),
+  writtenFile: writtenFileShcema,
 });
 
 export const clusterHighConfidenceActionsStepOutputSchema = z.object({


### PR DESCRIPTION
Linear取得件数を3件から20件に変更してテスト用データを増加。

ワークフローの簡素化：
- sendSlackQuestionStepを削除してワークフローを単純化
- クラスタリングステップの実行前にquestions削除でデータクリーンアップ
- エラーハンドリングを簡素化しより直接的な実装に変更
- import文の順序を整理

これらの変更により、ワークフローがより実用的で
メンテナンスしやすくなりました。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>